### PR TITLE
Implement basic survey schema

### DIFF
--- a/src/workweek_survey/schema.py
+++ b/src/workweek_survey/schema.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass, asdict
+from typing import List, Optional
+import json
+
+
+@dataclass
+class TaskEntry:
+    """Single task reported in the survey."""
+    name: str
+    duration_hours: float
+    category: str
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("name must not be empty")
+        if self.duration_hours <= 0:
+            raise ValueError("duration_hours must be positive")
+        if not self.category:
+            raise ValueError("category must not be empty")
+
+
+@dataclass
+class SurveyResponse:
+    """All tasks submitted by a team member."""
+    tasks: List[TaskEntry]
+    respondent: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not self.tasks:
+            raise ValueError("tasks must not be empty")
+
+
+def loads(data: str) -> SurveyResponse:
+    """Parse a JSON string into a SurveyResponse."""
+    raw = json.loads(data)
+    tasks = [TaskEntry(**item) for item in raw.get("tasks", [])]
+    respondent = raw.get("respondent")
+    return SurveyResponse(tasks=tasks, respondent=respondent)
+
+
+def dumps(response: SurveyResponse) -> str:
+    """Serialize a SurveyResponse into JSON."""
+    return json.dumps(asdict(response))

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,42 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+import json
+import pytest
+
+from workweek_survey import schema
+
+
+def sample_payload():
+    return {
+        "respondent": "alice",
+        "tasks": [
+            {"name": "coding", "duration_hours": 5, "category": "dev"},
+            {"name": "meeting", "duration_hours": 1, "category": "communication"},
+        ],
+    }
+
+
+def test_loads_valid():
+    payload = sample_payload()
+    data = json.dumps(payload)
+    resp = schema.loads(data)
+    assert resp.respondent == "alice"
+    assert len(resp.tasks) == 2
+    assert resp.tasks[0].name == "coding"
+    assert resp.tasks[0].duration_hours == 5
+
+
+def test_loads_invalid_duration():
+    payload = sample_payload()
+    payload["tasks"][0]["duration_hours"] = 0
+    data = json.dumps(payload)
+    with pytest.raises(ValueError):
+        schema.loads(data)
+
+
+def test_dumps_round_trip():
+    payload = sample_payload()
+    resp = schema.loads(json.dumps(payload))
+    dumped = schema.dumps(resp)
+    reloaded = schema.loads(dumped)
+    assert reloaded == resp


### PR DESCRIPTION
## Summary
- add `schema.py` defining `TaskEntry` and `SurveyResponse`
- parse JSON strings and serialize responses
- test schema validation and round‑trip functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687b1b5f7a90832e9ef4a338aa9be367