### PR TITLE
Implement survey frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+ENV/
+*.sqlite
+.pytest_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "uvicorn[standard]",
   "python-dotenv",
   "pyyaml",
+  "jinja2",
 ]
 [project.optional-dependencies]
 dev = [

--- a/src/workweek_survey/main.py
+++ b/src/workweek_survey/main.py
@@ -1,21 +1,27 @@
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
 import json
 import os
+from pathlib import Path
 from typing import List
 import yaml
 
 from . import schema
 
+BASE_DIR = Path(__file__).parent
 app = FastAPI()
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
 
 # In-memory storage for submitted survey responses
 _RESPONSES: List[schema.SurveyResponse] = []
 
 @app.get("/survey", response_class=HTMLResponse)
-async def get_survey() -> str:
-    """Serve the survey form. Placeholder HTML for now."""
-    return "<html><body><h1>Workweek Survey</h1></body></html>"
+async def get_survey(request: Request):
+    """Serve the survey form."""
+    return templates.TemplateResponse("survey.html", {"request": request})
 
 @app.post("/submit")
 async def submit(request: Request):

--- a/src/workweek_survey/static/styles.css
+++ b/src/workweek_survey/static/styles.css
@@ -1,0 +1,3 @@
+body { font-family: sans-serif; margin: 2em; }
+.task { margin-bottom: 0.5em; }
+#message { margin-top: 1em; color: green; }

--- a/src/workweek_survey/templates/survey.html
+++ b/src/workweek_survey/templates/survey.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Workweek Survey</title>
+    <link rel="stylesheet" href="{{ url_for('static', path='styles.css') }}">
+</head>
+<body>
+<h1>Workweek Survey</h1>
+<form id="survey-form">
+    <label>Respondent: <input type="text" name="respondent" id="respondent" /></label>
+    <div id="tasks">
+        <div class="task">
+            <input type="text" name="task-name" placeholder="Task name" required />
+            <input type="number" step="0.1" name="task-hours" placeholder="Hours" required />
+            <input type="text" name="task-category" placeholder="Category" required />
+        </div>
+    </div>
+    <button type="button" id="add-task">Add Task</button>
+    <button type="submit">Submit</button>
+</form>
+<div id="message" style="display:none;"></div>
+<script>
+const form = document.getElementById('survey-form');
+form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const tasks = [];
+    document.querySelectorAll('.task').forEach(el => {
+        tasks.push({
+            name: el.querySelector('input[name="task-name"]').value,
+            duration_hours: parseFloat(el.querySelector('input[name="task-hours"]').value),
+            category: el.querySelector('input[name="task-category"]').value,
+        });
+    });
+    const data = {respondent: document.getElementById('respondent').value, tasks};
+    const resp = await fetch('/submit', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(data)
+    });
+    const msg = document.getElementById('message');
+    msg.style.display = 'block';
+    if (resp.ok) {
+        msg.textContent = 'Thanks for submitting!';
+    } else {
+        msg.textContent = 'Submission failed.';
+    }
+});
+
+document.getElementById('add-task').addEventListener('click', () => {
+    const div = document.createElement('div');
+    div.className = 'task';
+    div.innerHTML = '<input type="text" name="task-name" placeholder="Task name" required />' +
+        '<input type="number" step="0.1" name="task-hours" placeholder="Hours" required />' +
+        '<input type="text" name="task-category" placeholder="Category" required />';
+    document.getElementById('tasks').appendChild(div);
+});
+</script>
+</body>
+</html>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,6 +21,12 @@ def test_submit_returns_200():
     assert response.json()["status"] == "ok"
 
 
+def test_get_survey_page():
+    response = client.get("/survey")
+    assert response.status_code == 200
+    assert "<form" in response.text
+
+
 def test_export_json():
     os.environ["OUTPUT_FORMAT"] = "json"
     client.post("/submit", json=sample_payload())


### PR DESCRIPTION
## Summary
- add jinja2 dependency
- include HTML survey form and CSS
- mount templates and static files in main app
- test `/survey` endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687b1f825df8832e8cf35dc7d1bb405d