### PR TITLE
Implement storage and configuration modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "python-dotenv",
   "pyyaml",
   "jinja2",
+  "pydantic-settings",
 ]
 [project.optional-dependencies]
 dev = [

--- a/roadmap.yaml
+++ b/roadmap.yaml
@@ -64,7 +64,7 @@
 - task_id: T005
   title: Data storage module
   description: Implement a storage layer that appends each response to disk in the chosen format under `STORAGE_PATH`.
-  status: todo
+  status: done
   dependencies: [T003]
   files_to_create:
     - src/workweek_survey/storage.py
@@ -77,7 +77,7 @@
 - task_id: T006
   title: Environment and config
   description: Load `.env`, validate required keys, and make configuration available to the app.
-  status: todo
+  status: done
   dependencies: [T001]
   files_to_create:
     - src/workweek_survey/config.py

--- a/src/workweek_survey/config.py
+++ b/src/workweek_survey/config.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pydantic import ValidationError, field_validator
+from pydantic_settings import BaseSettings
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class Settings(BaseSettings):
+    storage_path: str
+    output_format: str = "json"
+
+    @field_validator("output_format")
+    def validate_format(cls, v: str) -> str:
+        lv = v.lower()
+        if lv not in {"json", "yaml"}:
+            raise ValueError("OUTPUT_FORMAT must be 'json' or 'yaml'")
+        return lv
+
+    class Config:
+        env_prefix = ""
+        env_file = ".env"
+
+
+def get_settings() -> Settings:
+    """Load settings from the environment."""
+    try:
+        return Settings()
+    except ValidationError as exc:
+        raise RuntimeError(f"Invalid configuration: {exc}") from exc

--- a/src/workweek_survey/main.py
+++ b/src/workweek_survey/main.py
@@ -3,12 +3,12 @@ from fastapi.responses import HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 import json
-import os
 from pathlib import Path
 from typing import List
 import yaml
 
 from . import schema
+from .config import get_settings
 
 BASE_DIR = Path(__file__).parent
 app = FastAPI()
@@ -40,7 +40,7 @@ async def submit(request: Request):
 @app.get("/export")
 async def export() -> Response:
     """Export collected responses in OUTPUT_FORMAT."""
-    fmt = os.getenv("OUTPUT_FORMAT", "json").lower()
+    fmt = get_settings().output_format
     if fmt == "json":
         data = [json.loads(schema.dumps(r)) for r in _RESPONSES]
         return JSONResponse(content=data)

--- a/src/workweek_survey/storage.py
+++ b/src/workweek_survey/storage.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List
+
+import yaml
+
+from . import schema
+from .config import get_settings
+
+
+def _get_storage_dir() -> Path:
+    settings = get_settings()
+    path = Path(settings.storage_path)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _get_format() -> str:
+    return get_settings().output_format
+
+
+def append_response(response: schema.SurveyResponse) -> Path:
+    """Append a SurveyResponse to disk.
+
+    Each response is stored as a separate file inside STORAGE_PATH. The filename
+    uses a monotonic counter to avoid collisions and the file extension matches
+    OUTPUT_FORMAT (json or yaml).
+    """
+    storage_dir = _get_storage_dir()
+    fmt = _get_format()
+    ext = "json" if fmt == "json" else "yaml"
+
+    # Determine filename based on existing files count
+    count = len(list(storage_dir.glob(f"*.{ext}")))
+    filename = storage_dir / f"response_{count + 1}.{ext}"
+
+    if fmt == "json":
+        data = json.loads(schema.dumps(response))
+        filename.write_text(json.dumps(data))
+    elif fmt == "yaml":
+        data = json.loads(schema.dumps(response))
+        filename.write_text(yaml.safe_dump(data))
+    else:
+        raise ValueError(f"Unsupported OUTPUT_FORMAT: {fmt}")
+
+    return filename
+
+
+def read_responses() -> List[schema.SurveyResponse]:
+    """Read all stored responses from disk."""
+    storage_dir = _get_storage_dir()
+    fmt = _get_format()
+    ext = "json" if fmt == "json" else "yaml"
+    responses = []
+    for path in sorted(storage_dir.glob(f"*.{ext}")):
+        text = path.read_text()
+        if fmt == "json":
+            raw = text
+        else:
+            raw = json.dumps(yaml.safe_load(text))
+        responses.append(schema.loads(raw))
+    return responses

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
+import os
+os.environ.setdefault("STORAGE_PATH", "/tmp/workweek_test")
 from fastapi.testclient import TestClient
 from workweek_survey.main import app
-import os
 
 client = TestClient(app)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,19 @@
+import importlib
+import os
+import pytest
+
+
+def test_missing_storage_path(monkeypatch):
+    monkeypatch.delenv("STORAGE_PATH", raising=False)
+    monkeypatch.setenv("OUTPUT_FORMAT", "json")
+    with pytest.raises(RuntimeError):
+        importlib.reload(importlib.import_module("workweek_survey.config")).get_settings()
+
+
+def test_settings_loaded(monkeypatch, tmp_path):
+    monkeypatch.setenv("STORAGE_PATH", str(tmp_path))
+    monkeypatch.setenv("OUTPUT_FORMAT", "yaml")
+    mod = importlib.reload(importlib.import_module("workweek_survey.config"))
+    settings = mod.get_settings()
+    assert settings.storage_path == str(tmp_path)
+    assert settings.output_format == "yaml"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,4 +1,5 @@
 import os, sys
+os.environ.setdefault("STORAGE_PATH", "/tmp/workweek_test")
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 import json
 import pytest

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,37 @@
+import json
+import os
+os.environ.setdefault("STORAGE_PATH", "/tmp/workweek_test")
+
+from workweek_survey import schema, storage
+
+
+def sample_payload():
+    return {
+        "respondent": "alice",
+        "tasks": [
+            {"name": "coding", "duration_hours": 5, "category": "dev"},
+            {"name": "meeting", "duration_hours": 1, "category": "communication"},
+        ],
+    }
+
+
+def test_append_and_read_json(tmp_path, monkeypatch):
+    monkeypatch.setenv("STORAGE_PATH", str(tmp_path))
+    monkeypatch.setenv("OUTPUT_FORMAT", "json")
+    resp = schema.loads(json.dumps(sample_payload()))
+    path = storage.append_response(resp)
+    assert path.exists()
+    assert path.suffix == ".json"
+    responses = storage.read_responses()
+    assert responses == [resp]
+
+
+def test_append_and_read_yaml(tmp_path, monkeypatch):
+    monkeypatch.setenv("STORAGE_PATH", str(tmp_path))
+    monkeypatch.setenv("OUTPUT_FORMAT", "yaml")
+    resp = schema.loads(json.dumps(sample_payload()))
+    path = storage.append_response(resp)
+    assert path.exists()
+    assert path.suffix == ".yaml"
+    responses = storage.read_responses()
+    assert responses == [resp]


### PR DESCRIPTION
## Summary
- add persistent storage layer
- introduce configuration handling using `pydantic-settings`
- integrate configuration into main app and storage
- mark roadmap tasks T005 and T006 as complete
- expand test suite for new modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687b270b1bb4832e821debbf2a3e291f