### PR TITLE
Implement e2e test

### DIFF
--- a/roadmap.yaml
+++ b/roadmap.yaml
@@ -49,7 +49,7 @@
 - task_id: T004
   title: Frontend survey form
   description: Create a minimal HTML/CSS/JS page that renders the questions defined in schema.py and submits via AJAX.
-  status: todo
+  status: done
   dependencies: [T003]
   files_to_create:
     - src/workweek_survey/templates/survey.html
@@ -105,7 +105,7 @@
 - task_id: T008
   title: Write end-to-end tests
   description: Use pytest and httpx to test the full survey flow from `GET /survey` through `POST /submit` and `GET /export`.
-  status: todo
+  status: done
   dependencies: [T003, T005]
   files_to_create:
     - tests/test_survey_flow.py

--- a/tests/test_survey_flow.py
+++ b/tests/test_survey_flow.py
@@ -1,0 +1,37 @@
+import os
+from fastapi.testclient import TestClient
+from workweek_survey.main import app
+
+client = TestClient(app)
+
+
+def sample_payload():
+    return {
+        "respondent": "e2e-user",
+        "tasks": [
+            {"name": "code", "duration_hours": 2, "category": "dev"},
+            {"name": "review", "duration_hours": 1, "category": "dev"},
+        ],
+    }
+
+
+def test_end_to_end_flow(tmp_path, monkeypatch):
+    monkeypatch.setenv("STORAGE_PATH", str(tmp_path))
+    monkeypatch.setenv("OUTPUT_FORMAT", "json")
+
+    # GET survey page
+    response = client.get("/survey")
+    assert response.status_code == 200
+    assert "<form" in response.text
+
+    # Submit payload
+    response = client.post("/submit", json=sample_payload())
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+    # Export responses
+    response = client.get("/export")
+    assert response.status_code == 200
+    data = response.json()
+    assert data[-1]["respondent"] == "e2e-user"
+    assert data[-1]["tasks"][0]["name"] == "code"


### PR DESCRIPTION
## Summary
- mark frontend task as complete
- add end-to-end test for survey workflow
- mark e2e testing task as complete in roadmap

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687b28ffa80c832ebf2d7e0d115310f8