### PR TITLE
Implement dashboard task

### DIFF
--- a/src/workweek_survey/dashboard.py
+++ b/src/workweek_survey/dashboard.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from fastapi import Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from pathlib import Path
+
+BASE_DIR = Path(__file__).parent
+
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+
+
+async def dashboard(request: Request) -> HTMLResponse:
+    """Render the interactive analytics dashboard."""
+    return templates.TemplateResponse("dashboard.html", {"request": request})

--- a/src/workweek_survey/main.py
+++ b/src/workweek_survey/main.py
@@ -10,6 +10,7 @@ import yaml
 from . import schema
 from .config import get_settings
 from . import utils
+from .dashboard import dashboard as dashboard_view
 
 BASE_DIR = Path(__file__).parent
 app = FastAPI()
@@ -53,3 +54,9 @@ async def export() -> Response:
         return Response(content=yaml_str, media_type="application/x-yaml")
     else:
         raise HTTPException(status_code=500, detail="Unsupported OUTPUT_FORMAT")
+
+
+@app.get("/dashboard", response_class=HTMLResponse)
+async def dashboard(request: Request):
+    """Serve the interactive analytics dashboard."""
+    return await dashboard_view(request)

--- a/src/workweek_survey/schema.py
+++ b/src/workweek_survey/schema.py
@@ -24,6 +24,7 @@ class SurveyResponse:
     """All tasks submitted by a team member."""
     tasks: List[TaskEntry]
     respondent: Optional[str] = None
+    org_branch: Optional[str] = None
 
     def __post_init__(self) -> None:
         if not self.tasks:
@@ -35,7 +36,8 @@ def loads(data: str) -> SurveyResponse:
     raw = json.loads(data)
     tasks = [TaskEntry(**item) for item in raw.get("tasks", [])]
     respondent = raw.get("respondent")
-    return SurveyResponse(tasks=tasks, respondent=respondent)
+    org_branch = raw.get("org_branch")
+    return SurveyResponse(tasks=tasks, respondent=respondent, org_branch=org_branch)
 
 
 def dumps(response: SurveyResponse) -> str:

--- a/src/workweek_survey/static/dashboard.js
+++ b/src/workweek_survey/static/dashboard.js
@@ -1,0 +1,35 @@
+async function loadData() {
+    const res = await fetch('/export');
+    if (!res.ok) return;
+    const data = await res.json();
+    const responses = data.responses || [];
+    const branches = new Set();
+    responses.forEach(r => {
+        if (r.org_branch) {
+            branches.add(r.org_branch);
+        }
+    });
+    const select = document.getElementById('branch-select');
+    select.innerHTML = '<option value="">All</option>' +
+        Array.from(branches).map(b => `<option value="${b}">${b}</option>`).join('');
+    select.addEventListener('change', () => render(select.value, responses));
+    render('', responses);
+}
+
+function render(branch, responses) {
+    const filtered = branch ? responses.filter(r => r.org_branch === branch) : responses;
+    const totals = {};
+    filtered.forEach(r => {
+        r.tasks.forEach(t => {
+            totals[t.name] = (totals[t.name] || 0) + t.duration_hours;
+        });
+    });
+    const sum = Object.values(totals).reduce((a, b) => a + b, 0);
+    const chart = document.getElementById('chart');
+    chart.innerHTML = Object.entries(totals).map(([name, hours]) => {
+        const pct = sum ? ((hours / sum) * 100).toFixed(1) : 0;
+        return `<div>${name}: ${pct}%</div>`;
+    }).join('');
+}
+
+window.addEventListener('load', loadData);

--- a/src/workweek_survey/templates/dashboard.html
+++ b/src/workweek_survey/templates/dashboard.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Survey Dashboard</title>
+    <script src="{{ url_for('static', path='dashboard.js') }}"></script>
+</head>
+<body>
+<h1>Survey Dashboard</h1>
+<label>Org Branch:
+    <select id="branch-select"></select>
+</label>
+<div id="chart"></div>
+</body>
+</html>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,12 @@
+import os
+from fastapi.testclient import TestClient
+from workweek_survey.main import app
+
+client = TestClient(app)
+
+
+def test_dashboard_route():
+    response = client.get("/dashboard")
+    assert response.status_code == 200
+    assert "Survey Dashboard" in response.text
+


### PR DESCRIPTION
## Summary
- implement `/dashboard` route
- add dashboard HTML template
- add interactive JS to filter by branch and show percentages
- extend SurveyResponse schema with optional `org_branch`
- test dashboard route

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687bc06d8d08832e81fb836d6e1fe3a5