### PR TITLE
Fix deprecated APIs

### DIFF
--- a/src/workweek_survey/config.py
+++ b/src/workweek_survey/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pydantic import ValidationError, field_validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -18,9 +18,7 @@ class Settings(BaseSettings):
             raise ValueError("OUTPUT_FORMAT must be 'json' or 'yaml'")
         return lv
 
-    class Config:
-        env_prefix = ""
-        env_file = ".env"
+    model_config = SettingsConfigDict(env_prefix="", env_file=".env")
 
 
 def get_settings() -> Settings:

--- a/src/workweek_survey/dashboard.py
+++ b/src/workweek_survey/dashboard.py
@@ -12,4 +12,4 @@ templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
 async def dashboard(request: Request) -> HTMLResponse:
     """Render the interactive analytics dashboard."""
-    return templates.TemplateResponse("dashboard.html", {"request": request})
+    return templates.TemplateResponse(request, "dashboard.html")

--- a/src/workweek_survey/main.py
+++ b/src/workweek_survey/main.py
@@ -23,7 +23,7 @@ _RESPONSES: List[schema.SurveyResponse] = []
 @app.get("/survey", response_class=HTMLResponse)
 async def get_survey(request: Request):
     """Serve the survey form."""
-    return templates.TemplateResponse("survey.html", {"request": request})
+    return templates.TemplateResponse(request, "survey.html")
 
 @app.post("/submit")
 async def submit(request: Request):

--- a/src/workweek_survey/utils.py
+++ b/src/workweek_survey/utils.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, UTC
 
 
 def current_survey_year() -> int:
     """Return the current year for tagging exports."""
-    return datetime.utcnow().year
+    return datetime.now(UTC).year


### PR DESCRIPTION
## Summary
- fix pydantic config deprecation by using `SettingsConfigDict`
- update TemplateResponse usage for starlette 0.37+
- avoid `datetime.utcnow` deprecation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687bd29c5b50832e984965e9a525f296